### PR TITLE
fix tennis

### DIFF
--- a/improvements.js
+++ b/improvements.js
@@ -527,6 +527,11 @@
       sanitized.segment = NFL_PROP_MARKETS_BY_SEGMENT[sanitized.market];
     }
 
+    if (sanitized.league === 'Tennis') {
+      const [first_name, last_name] = sanitized.team2.split(' ');
+      sanitized.team2 = `${first_name[0]}. ${last_name}`;
+    }
+
     sanitized.value = sanitized.value.replace("Under ", " u").replace("Over ", " o");
     console.log("Sanitized");
     console.log(sanitized);


### PR DESCRIPTION
Tennis URLs seem to all use `team2` as the matching name to navigate. Nav broke because
the 'browse odds' page uses an initial for the first name whereas the
other pages list the full name.
